### PR TITLE
chore: harden GitHub Actions security (SHA pin, zizmor, betterleaks)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,30 @@ name: CI
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
+
+# Cancel duplicate runs when a PR is force-pushed; only the
+# latest commit's checks are interesting.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.10
 
@@ -25,3 +37,28 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  workflow-lint:
+    # Audits the GitHub Actions workflows themselves. zizmor flags
+    # the common Action security pitfalls (mutable refs, missing
+    # persist-credentials, overbroad permissions, ...).
+    runs-on: ubuntu-latest
+    # zizmor-action internally calls `github/codeql-action/
+    # upload-sarif` to surface findings in the repo's Security
+    # tab. Without `security-events: write` that step fails with
+    # "Resource not accessible by integration" and the whole job
+    # exits non-zero even though zizmor itself reported no
+    # findings.
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # Pinned to a specific tag; zizmorcore/zizmor-action
+        # doesn't publish a moving major tag.
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# https://docs.zizmor.sh/configuration/
+#
+# We now SHA-pin every action in the workflows, so zizmor's
+# default `hash-pin` policy applies project-wide with no
+# overrides. Dependabot drives the bumps; the `# v<tag>` comment
+# next to each SHA keeps the human-readable version visible.
+rules: {}

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@types/node": "^20.19.30",
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.7",
+        "lefthook": "^1.7",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.9.3",
@@ -492,6 +493,28 @@
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lefthook": ["lefthook@1.13.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.13.6", "lefthook-darwin-x64": "1.13.6", "lefthook-freebsd-arm64": "1.13.6", "lefthook-freebsd-x64": "1.13.6", "lefthook-linux-arm64": "1.13.6", "lefthook-linux-x64": "1.13.6", "lefthook-openbsd-arm64": "1.13.6", "lefthook-openbsd-x64": "1.13.6", "lefthook-windows-arm64": "1.13.6", "lefthook-windows-x64": "1.13.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@1.13.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@1.13.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@1.13.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@1.13.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@1.13.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@1.13.6", "", { "os": "linux", "cpu": "x64" }, "sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@1.13.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@1.13.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@1.13.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@1.13.6", "", { "os": "win32", "cpu": "x64" }, "sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,13 +21,10 @@ pre-commit:
       run: bun run check
     betterleaks:
       tags: security
-      # `--staged` is the right scope for a secret scanner — only
-      # content that's about to be committed can leak secrets into
-      # the repo. A full-tree scan doesn't add safety, just latency.
-      run: betterleaks git --pre-commit --redact --staged --verbose
+      # Scan the whole repo, not just staged files — same scope as
+      # biome so unstaged secret drift is caught before commit.
+      run: betterleaks git . --redact --verbose
     zizmor:
       tags: security
-      # GitHub Actions security / lint. Only runs when a workflow
-      # file is staged, so the day-to-day commit cost is zero.
-      glob: ".github/workflows/*.{yml,yaml}"
-      run: zizmor {staged_files}
+      # Audit all workflow files on every commit, not just staged ones.
+      run: zizmor .github/workflows/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,33 @@
+# https://github.com/evilmartians/lefthook
+#
+# After installing dependencies, wire the hooks into .git/hooks once:
+#
+#   bunx lefthook install
+#
+# Skip a hook ad-hoc with LEFTHOOK_EXCLUDE=<command_name>.
+#
+# External binaries (install once):
+#   brew install betterleaks zizmor
+#   pipx install zizmor  # alternative for zizmor
+
+pre-commit:
+  parallel: true
+  commands:
+    biome:
+      tags: lint
+      # Scan the whole project, not just staged files. CI runs the
+      # same `bun run check` so the local hook catches the same
+      # violations CI would.
+      run: bun run check
+    betterleaks:
+      tags: security
+      # `--staged` is the right scope for a secret scanner — only
+      # content that's about to be committed can leak secrets into
+      # the repo. A full-tree scan doesn't add safety, just latency.
+      run: betterleaks git --pre-commit --redact --staged --verbose
+    zizmor:
+      tags: security
+      # GitHub Actions security / lint. Only runs when a workflow
+      # file is staged, so the day-to-day commit cost is zero.
+      glob: ".github/workflows/*.{yml,yaml}"
+      run: zizmor {staged_files}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
+		"lefthook": "^1.7",
 		"@types/mdx": "^2.0.13",
 		"@types/node": "^20.19.30",
 		"@types/react": "^18.3.27",


### PR DESCRIPTION
## Summary

- SHA-pin all GitHub Actions in `ci.yml` with `# vX.Y.Z` comments
- Add workflow hardening: `permissions: contents: read`, `concurrency`, `persist-credentials: false`
- Add `workflow-lint` job running `zizmorcore/zizmor-action` (SARIF upload via `security-events: write`)
- Add `.github/zizmor.yml` and Dependabot for `github-actions`
- Add `lefthook` pre-commit hooks: Biome (`bun run check`), betterleaks, zizmor (workflow files only)

## Test plan

- [x] `bun install && bunx lefthook install`
- [x] `bunx lefthook run pre-commit` with staged workflow files — biome / betterleaks / zizmor pass
- [x] `zizmor .github/workflows/` — no findings
- [ ] CI: `lint-and-build` and `workflow-lint` jobs green on this PR

## Manual follow-up (post-merge)

Enable **Settings → Actions → General → Allow specified actions** and allow at minimum:

- `actions/checkout`
- `oven-sh/setup-bun`
- `zizmorcore/zizmor-action`
- `github/codeql-action/*`

Local dev setup for hooks:

```sh
brew install betterleaks zizmor   # or: pipx install zizmor
bun install
bunx lefthook install
```

Made with [Cursor](https://cursor.com)