### PR TITLE
fix: ホームページの Tailwind クラス名タイポを修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,18 +20,18 @@ export default function Home() {
 					craft.
 				</TypographyP>
 			</div>
-			<div className="flex flex-row item-start gap-4">
+			<div className="flex flex-row items-start gap-4">
 				<Link
 					href="https://x.com/nozomemein"
 					target="_blank"
-					className="text-primay underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
+					className="text-primary underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
 				>
 					Twitter/X
 				</Link>
 				<Link
 					href="https://github.com/nozomemein"
 					target="_blank"
-					className="text-primay underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
+					className="text-primary underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
 				>
 					GitHub
 				</Link>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
`app/page.tsx` の Tailwind クラス名のタイポを修正しました。

## 変更内容
- `text-primay` → `text-primary` (2箇所) - リンクの色が正しく適用されるようになりました
- `item-start` → `items-start` - flexbox の align-items が正しく適用されるようになりました

## 確認事項
- [x] `bun run check` が通ること
- [x] `bun run build` が通ること

Closes #（該当する issue があれば）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99fc0829-868a-4841-a773-26bb992cc55c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99fc0829-868a-4841-a773-26bb992cc55c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

