### PR TITLE
feat: add OG images for home, blog index, and privacy pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,12 @@ content/blog/*.mdx → lib/posts.ts → app/blog/[slug]/page.tsx → next build 
 | `lib/link/card-urls.ts` | Extract `<LinkCard href="...">` URLs from MDX source |
 | `lib/link/preview-utils.ts` | Link preview cache TTL and image URL helpers |
 | `lib/link/previews.ts` | LinkCard OGP preview cache loader |
-| `app/blog/[slug]/opengraph-image.tsx` | Generated OG images via `ImageResponse` |
+| `lib/og/colors.ts` | Dark theme colors for generated OG images |
+| `lib/og/image-response.tsx` | Shared `ImageResponse` builder for OG images |
+| `app/opengraph-image.tsx` | Home page OG image |
+| `app/blog/opengraph-image.tsx` | Blog index OG image |
+| `app/blog/[slug]/opengraph-image.tsx` | Blog post OG images |
+| `app/privacy/opengraph-image.tsx` | Privacy page OG image |
 | `assets/fonts/` | Fonts used by generated OG images |
 | `scripts/fetch-link-previews.ts` | Build-time OGP fetch for `<LinkCard>` URLs |
 | `content/generated/link-previews.json` | Cached external link previews |
@@ -79,10 +84,12 @@ After any change that affects appearance (layout, styling, components, typograph
 2. Open the affected page(s) at `http://localhost:3000`
 3. Check both light and dark mode when the change may affect theme styling
 
-For **OG images**, preview the generated image directly after changing `app/blog/[slug]/opengraph-image.tsx`, `lib/og/colors.ts`, or blog post titles:
+For **OG images**, preview the generated image directly after changing `lib/og/image-response.tsx`, `lib/og/colors.ts`, route-level `opengraph-image.tsx` files, or blog post titles:
 
-- `http://localhost:3000/blog/<slug>/opengraph-image`
-- Example: `http://localhost:3000/blog/hello/opengraph-image`
+- Home: `http://localhost:3000/opengraph-image`
+- Blog index: `http://localhost:3000/blog/opengraph-image`
+- Blog post: `http://localhost:3000/blog/<slug>/opengraph-image` (e.g. `/blog/hello/opengraph-image`)
+- Privacy: `http://localhost:3000/privacy/opengraph-image`
 
 Reload after edits to confirm title text, colors, and layout look correct.
 

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,33 +1,18 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { notFound } from "next/navigation";
-import { ImageResponse } from "next/og";
-import { config } from "@/lib/constants";
-import { ogImageTheme } from "@/lib/og/colors";
+import {
+	createOgImageResponse,
+	ogImageContentType,
+	ogImageSize,
+} from "@/lib/og/image-response";
 import { getPostFrontmatterBySlug } from "@/lib/post-frontmatter";
 import { getAllSlugs } from "@/lib/posts";
 
-export const size = { width: 1200, height: 630 };
-export const contentType = "image/png";
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const dynamic = "force-static";
 
 export function generateStaticParams() {
 	return getAllSlugs({ includeDrafts: false }).map((slug) => ({ slug }));
-}
-
-let fontDataPromise: Promise<ArrayBuffer> | null = null;
-
-function getFontData() {
-	if (!fontDataPromise) {
-		fontDataPromise = readFile(
-			path.join(process.cwd(), "assets/fonts/NotoSansJP-Bold.woff"),
-		).then((buffer) =>
-			buffer.buffer.slice(
-				buffer.byteOffset,
-				buffer.byteOffset + buffer.byteLength,
-			),
-		);
-	}
-	return fontDataPromise;
 }
 
 export default async function OpenGraphImage({
@@ -42,55 +27,7 @@ export default async function OpenGraphImage({
 		notFound();
 	}
 
-	const fontData = await getFontData();
-
-	return new ImageResponse(
-		<div
-			style={{
-				display: "flex",
-				flexDirection: "column",
-				justifyContent: "space-between",
-				width: "100%",
-				height: "100%",
-				backgroundColor: ogImageTheme.background,
-				padding: "80px",
-			}}
-		>
-			<div
-				style={{
-					display: "flex",
-					flex: 1,
-					alignItems: "center",
-					fontSize: 64,
-					fontWeight: 700,
-					color: ogImageTheme.foreground,
-					fontFamily: "Noto Sans JP",
-					lineHeight: 1.3,
-				}}
-			>
-				{frontmatter.title}
-			</div>
-			<div
-				style={{
-					fontSize: 28,
-					fontWeight: 500,
-					color: ogImageTheme.mutedForeground,
-					fontFamily: "Noto Sans JP",
-				}}
-			>
-				{config.site.name}
-			</div>
-		</div>,
-		{
-			...size,
-			fonts: [
-				{
-					name: "Noto Sans JP",
-					data: fontData,
-					style: "normal",
-					weight: 700,
-				},
-			],
-		},
-	);
+	return createOgImageResponse({
+		title: frontmatter.title,
+	});
 }

--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import {
+	createOgImageResponse,
+	ogImageContentType,
+	ogImageSize,
+} from "@/lib/og/image-response";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const dynamic = "force-static";
+
+export default async function OpenGraphImage() {
+	return createOgImageResponse({
+		title: "Blog",
+	});
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import { config } from "@/lib/constants";
+import {
+	createOgImageResponse,
+	ogImageContentType,
+	ogImageSize,
+} from "@/lib/og/image-response";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const dynamic = "force-static";
+
+export default async function OpenGraphImage() {
+	return createOgImageResponse({
+		title: config.site.name,
+		footer: config.site.description,
+	});
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -12,6 +12,6 @@ export const dynamic = "force-static";
 export default async function OpenGraphImage() {
 	return createOgImageResponse({
 		title: config.site.name,
-		footer: config.site.description,
+		footer: null,
 	});
 }

--- a/app/privacy/opengraph-image.tsx
+++ b/app/privacy/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { frontmatter } from "@/content/pages/privacy.mdx";
+import {
+	createOgImageResponse,
+	ogImageContentType,
+	ogImageSize,
+} from "@/lib/og/image-response";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const dynamic = "force-static";
+
+export default async function OpenGraphImage() {
+	return createOgImageResponse({
+		title: frontmatter.title ?? "プライバシーポリシー",
+	});
+}

--- a/lib/og/image-response.tsx
+++ b/lib/og/image-response.tsx
@@ -25,14 +25,52 @@ function getFontData() {
 
 type CreateOgImageResponseOptions = {
 	title: string;
-	footer?: string;
+	/** Omit for site name; pass `null` to hide the footer row. */
+	footer?: string | null;
 };
 
 export async function createOgImageResponse({
 	title,
-	footer = config.site.name,
+	footer,
 }: CreateOgImageResponseOptions) {
 	const fontData = await getFontData();
+	const footerText = footer === undefined ? config.site.name : footer;
+	const fonts = [
+		{
+			name: "Noto Sans JP",
+			data: fontData,
+			style: "normal" as const,
+			weight: 700 as const,
+		},
+	];
+
+	if (!footerText) {
+		return new ImageResponse(
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					width: "100%",
+					height: "100%",
+					backgroundColor: ogImageTheme.background,
+					padding: "80px",
+				}}
+			>
+				<div
+					style={{
+						fontSize: 64,
+						fontWeight: 700,
+						color: ogImageTheme.foreground,
+						fontFamily: "Noto Sans JP",
+						lineHeight: 1.3,
+					}}
+				>
+					{title}
+				</div>
+			</div>,
+			{ ...ogImageSize, fonts },
+		);
+	}
 
 	return new ImageResponse(
 		<div
@@ -68,19 +106,9 @@ export async function createOgImageResponse({
 					fontFamily: "Noto Sans JP",
 				}}
 			>
-				{footer}
+				{footerText}
 			</div>
 		</div>,
-		{
-			...ogImageSize,
-			fonts: [
-				{
-					name: "Noto Sans JP",
-					data: fontData,
-					style: "normal",
-					weight: 700,
-				},
-			],
-		},
+		{ ...ogImageSize, fonts },
 	);
 }

--- a/lib/og/image-response.tsx
+++ b/lib/og/image-response.tsx
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { ImageResponse } from "next/og";
+import { config } from "@/lib/constants";
+import { ogImageTheme } from "@/lib/og/colors";
+
+export const ogImageSize = { width: 1200, height: 630 };
+export const ogImageContentType = "image/png";
+
+let fontDataPromise: Promise<ArrayBuffer> | null = null;
+
+function getFontData() {
+	if (!fontDataPromise) {
+		fontDataPromise = readFile(
+			path.join(process.cwd(), "assets/fonts/NotoSansJP-Bold.woff"),
+		).then((buffer) =>
+			buffer.buffer.slice(
+				buffer.byteOffset,
+				buffer.byteOffset + buffer.byteLength,
+			),
+		);
+	}
+	return fontDataPromise;
+}
+
+type CreateOgImageResponseOptions = {
+	title: string;
+	footer?: string;
+};
+
+export async function createOgImageResponse({
+	title,
+	footer = config.site.name,
+}: CreateOgImageResponseOptions) {
+	const fontData = await getFontData();
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				width: "100%",
+				height: "100%",
+				backgroundColor: ogImageTheme.background,
+				padding: "80px",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flex: 1,
+					alignItems: "center",
+					fontSize: 64,
+					fontWeight: 700,
+					color: ogImageTheme.foreground,
+					fontFamily: "Noto Sans JP",
+					lineHeight: 1.3,
+				}}
+			>
+				{title}
+			</div>
+			<div
+				style={{
+					fontSize: 28,
+					fontWeight: 500,
+					color: ogImageTheme.mutedForeground,
+					fontFamily: "Noto Sans JP",
+				}}
+			>
+				{footer}
+			</div>
+		</div>,
+		{
+			...ogImageSize,
+			fonts: [
+				{
+					name: "Noto Sans JP",
+					data: fontData,
+					style: "normal",
+					weight: 700,
+				},
+			],
+		},
+	);
+}


### PR DESCRIPTION
## Summary

- Add `opengraph-image.tsx` routes for `/`, `/blog`, and `/privacy` using the same dark-theme `ImageResponse` style as blog posts
- Extract shared OG image rendering into `lib/og/image-response.tsx` and refactor blog post OG generation to use it
- Set `dynamic = "force-static"` on all OG image routes for static export compatibility
- Document new OG preview URLs in `AGENTS.md`

## Test plan

- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build` (routes: `/opengraph-image`, `/blog/opengraph-image`, `/privacy/opengraph-image`)
- [x] Verified `og:image` meta tags in built HTML for `/`, `/blog`, `/privacy`
- [x] Previewed home OG image at `http://localhost:3000/opengraph-image`


Made with [Cursor](https://cursor.com)