### PR TITLE
fix: add rel="noopener noreferrer" to external links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ export default function Home() {
 				<Link
 					href="https://x.com/nozomemein"
 					target="_blank"
+					rel="noopener noreferrer"
 					className="text-primary underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
 				>
 					Twitter/X
@@ -31,6 +32,7 @@ export default function Home() {
 				<Link
 					href="https://github.com/nozomemein"
 					target="_blank"
+					rel="noopener noreferrer"
 					className="text-primary underline-offset-4 hover:underline text-sm font-medium inline-flex items-center"
 				>
 					GitHub

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -2,18 +2,31 @@ import type { MDXComponents } from "mdx/types";
 import { LinkCard } from "@/components/link-card";
 import { cn } from "@/lib/utils";
 
+function isExternalUrl(href: string | undefined): boolean {
+	if (!href) return false;
+	return href.startsWith("http://") || href.startsWith("https://");
+}
+
 export function useMDXComponents(components: MDXComponents): MDXComponents {
 	return {
 		LinkCard,
-		a: ({ className, ...props }) => (
-			<a
-				className={cn(
-					"text-blue-600 underline underline-offset-4 hover:text-blue-700 dark:text-sky-300 dark:hover:text-sky-200",
-					className,
-				)}
-				{...props}
-			/>
-		),
+		a: ({ className, href, ...props }) => {
+			const isExternal = isExternalUrl(href);
+			return (
+				<a
+					href={href}
+					className={cn(
+						"text-blue-600 underline underline-offset-4 hover:text-blue-700 dark:text-sky-300 dark:hover:text-sky-200",
+						className,
+					)}
+					{...(isExternal && {
+						target: "_blank",
+						rel: "noopener noreferrer",
+					})}
+					{...props}
+				/>
+			);
+		},
 		h1: ({ className, ...props }) => (
 			<h1
 				className={cn("text-3xl font-semibold tracking-tight", className)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the tabnabbing security risk by adding `rel="noopener noreferrer"` to all external links that use `target="_blank"`.

## Changes

### `app/page.tsx`
- Added `rel="noopener noreferrer"` to Twitter/X link
- Added `rel="noopener noreferrer"` to GitHub link

### `mdx-components.tsx`
- Added `isExternalUrl()` helper function to detect external URLs (http:// or https://)
- Updated the MDX `<a>` component to automatically add `target="_blank"` and `rel="noopener noreferrer"` for external links
- Internal links remain unchanged (no target/rel attributes)

## Acceptance Criteria

- [x] All `target="_blank"` links have `rel="noopener noreferrer"`
- [x] MDX component auto-detects external URLs and applies the attributes (recommended)

## Testing

- `bun run check` - Passed
- `bun test` - 25 tests passed
- `bun run build` - Build succeeded

Closes #7
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02cd1176-0f3b-4afa-b715-11141ca0ca7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02cd1176-0f3b-4afa-b715-11141ca0ca7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

