### PR TITLE
feat: add custom 404 page (not-found.tsx)

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+	title: "404",
+	robots: { index: false },
+};
+
+export default function NotFound() {
+	return (
+		<main className="mx-auto flex min-h-[60vh] w-full max-w-3xl flex-col items-center justify-center gap-6 px-6 py-16 text-center">
+			<h1 className="text-3xl font-semibold tracking-tight">Page Not Found</h1>
+			<p className="text-sm text-neutral-600 dark:text-muted-foreground">
+				The page you are looking for does not exist or has been moved.
+			</p>
+			<div className="flex gap-4">
+				<Button asChild>
+					<Link href="/">Home</Link>
+				</Button>
+				<Button variant="outline" asChild>
+					<Link href="/blog">Blog</Link>
+				</Button>
+			</div>
+		</main>
+	);
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,9 @@
 	"name": "nozodev",
 	"compatibility_date": "2026-01-31",
 	"assets": {
-		"directory": "./out"
+		"directory": "./out",
+		"not_found_handling": "404-page",
+		"html_handling": "auto-trailing-slash"
 	},
 	"env": {
 		"preview": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add a custom 404 page to display when users navigate to non-existent URLs.

Closes #35

## Changes
- Added `app/not-found.tsx` with a centered layout matching the site design
- Page includes navigation links to Home and Blog pages
- Metadata sets title to "404" and disables search engine indexing (`robots: { index: false }`)
- Updated `wrangler.jsonc` with `not_found_handling: "404-page"` so Cloudflare Workers Static Assets serves `404.html` as fallback

## Implementation Details
- Uses existing layout (header/footer displayed via `app/layout.tsx`)
- Styling matches other pages: `max-w-3xl`, centered content, consistent typography
- Works with static export - generates `out/404.html` at build time
- **Important:** This site deploys via Cloudflare Workers Static Assets (not Cloudflare Pages), so `not_found_handling: "404-page"` is required for the custom 404 HTML to be returned

## Acceptance Criteria
- [x] Custom 404 page displays for non-existent paths
- [x] Works with static export (`bun run build` generates `404.html`)
- [x] Preview deployment returns custom 404 HTML with HTTP 404 status

## Testing
- `bun run check` ✓
- `bun test` ✓
- `bun run build` ✓ (generates `out/404.html`)
- Preview: `curl -i https://cursor-custom-404-page-4fd0-nozodev.b8yukifsukeo999n.workers.dev/blog/xx` → HTTP 404 + `content-type: text/html` + custom 404 body ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efae20cd-5807-4eca-8022-0386d4764fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efae20cd-5807-4eca-8022-0386d4764fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

