### PR TITLE
fix: demote MDX h1 to h2 on blog post pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { buildBlogPostingJsonLd } from "@/lib/seo/blog-json-ld";
 import { buildPageOpenGraph, buildPageTwitter } from "@/lib/seo/page-metadata";
 import { serializeJsonLd } from "@/lib/seo/serialize-json-ld";
 import { config } from "@/lib/seo/site";
+import { DemotedMdxH1 } from "@/mdx-components";
 
 export const dynamicParams = false;
 
@@ -93,7 +94,7 @@ export default async function BlogPostPage({
 				</header>
 
 				<div className="space-y-6">
-					<Post />
+					<Post components={{ h1: DemotedMdxH1 }} />
 				</div>
 			</article>
 		</main>

--- a/lib/blog/posts.ts
+++ b/lib/blog/posts.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
-import type { ComponentType } from "react";
+import type { MDXContent } from "mdx/types";
 import {
 	type PostFrontmatterFields,
 	validatePostFrontmatterFields,
@@ -20,11 +20,11 @@ export type PostSummary = { slug: string; frontmatter: PostFrontmatter };
 export type PostModule = {
 	slug: string;
 	frontmatter: PostFrontmatter;
-	Component: ComponentType;
+	Component: MDXContent;
 };
 
 type MdxModule = {
-	default?: ComponentType;
+	default?: MDXContent;
 	frontmatter?: unknown;
 };
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,6 +1,13 @@
 import type { MDXComponents } from "mdx/types";
+import type { ComponentPropsWithoutRef } from "react";
 import { LinkCard } from "@/components/link-card";
 import { cn } from "@/lib/utils";
+
+export function DemotedMdxH1(props: ComponentPropsWithoutRef<"h1">) {
+	return (
+		<h2 {...props} className="mt-8 text-3xl font-semibold tracking-tight" />
+	);
+}
 
 function isExternalUrl(href: string | undefined): boolean {
 	if (!href) return false;

--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -1,8 +1,8 @@
 declare module "*.mdx" {
-	import type { ComponentType } from "react";
+	import type { MDXContent } from "mdx/types";
 	import type { BaseFrontmatter } from "./lib/blog/posts";
 
-	const MDXComponent: ComponentType;
+	const MDXComponent: MDXContent;
 	export const frontmatter: BaseFrontmatter;
 	export default MDXComponent;
 }


### PR DESCRIPTION
## Summary

- Add `DemotedMdxH1` to render MDX `#` headings as `<h2>` while preserving their visual styling
- Apply the demotion only on blog post pages via `<Post components={{ h1: DemotedMdxH1 }} />`, leaving `/privacy` unchanged
- Type MDX components as `MDXContent` so the `components` prop is accepted at build time

Closes #55

## Test plan

- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build`
- [x] Verified `/blog/2025-review` has exactly one `<h1>` (post title)
- [x] Verified `/privacy` still has one `<h1>` (no regression)


Made with [Cursor](https://cursor.com)