### PR TITLE
feat: add empty state UI for blog page with zero posts

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -36,36 +36,42 @@ export default async function BlogIndexPage() {
 			</header>
 
 			<section>
-				<ul className="divide-y divide-neutral-200">
-					{posts.map((post) => (
-						<li key={post.slug} className="py-6 first:pt-0">
-							<Link
-								href={`/blog/${post.slug}`}
-								className="group block space-y-2"
-							>
-								<h2 className="text-xl font-semibold tracking-tight group-hover:underline">
-									{post.frontmatter.title}
-								</h2>
-								<p className="text-sm text-neutral-600 dark:text-muted-foreground">
-									{post.frontmatter.description}
-								</p>
-								<div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
-									<time dateTime={post.frontmatter.date}>
-										{post.frontmatter.date}
-									</time>
-									{post.frontmatter.tags?.length ? (
-										<span aria-hidden="true">•</span>
-									) : null}
-									{post.frontmatter.tags?.map((tag) => (
-										<Badge key={tag} variant="secondary" className="text-xs">
-											#{tag}
-										</Badge>
-									))}
-								</div>
-							</Link>
-						</li>
-					))}
-				</ul>
+				{posts.length === 0 ? (
+					<p className="py-6 text-sm text-neutral-600 dark:text-muted-foreground">
+						まだ記事がありません
+					</p>
+				) : (
+					<ul className="divide-y divide-neutral-200">
+						{posts.map((post) => (
+							<li key={post.slug} className="py-6 first:pt-0">
+								<Link
+									href={`/blog/${post.slug}`}
+									className="group block space-y-2"
+								>
+									<h2 className="text-xl font-semibold tracking-tight group-hover:underline">
+										{post.frontmatter.title}
+									</h2>
+									<p className="text-sm text-neutral-600 dark:text-muted-foreground">
+										{post.frontmatter.description}
+									</p>
+									<div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+										<time dateTime={post.frontmatter.date}>
+											{post.frontmatter.date}
+										</time>
+										{post.frontmatter.tags?.length ? (
+											<span aria-hidden="true">•</span>
+										) : null}
+										{post.frontmatter.tags?.map((tag) => (
+											<Badge key={tag} variant="secondary" className="text-xs">
+												#{tag}
+											</Badge>
+										))}
+									</div>
+								</Link>
+							</li>
+						))}
+					</ul>
+				)}
 			</section>
 		</main>
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Added an empty state UI to the blog index page (`app/blog/page.tsx`) that displays a message when there are no blog posts.

## Changes

- Added conditional rendering to check if `posts.length === 0`
- When no posts exist, displays the message "まだ記事がありません" (There are no articles yet)
- The styling matches the existing description text style for consistency

## Screenshot

[Empty blog state showing まだ記事がありません message](https://cursor.com/agents/bc-c52d0fda-9105-4f2b-b725-6d4b355e50d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty-blog-state.png)

## Acceptance Criteria

- [x] Shows "まだ記事がありません" message when there are 0 posts

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c52d0fda-9105-4f2b-b725-6d4b355e50d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c52d0fda-9105-4f2b-b725-6d4b355e50d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

