### PR TITLE
perf: eliminate double MDX read in listBlogPosts

### DIFF
--- a/lib/content/blog/mdx.ts
+++ b/lib/content/blog/mdx.ts
@@ -48,14 +48,10 @@ function getFrontmatterStatusFromFile(filePath: string) {
 
 export { parseBlogFrontmatter };
 
-export function listBlogSlugs(_options?: {
-	includeDrafts?: boolean;
-}): string[] {
+function getCandidateSlugs(): string[] {
 	if (!fs.existsSync(blogDir)) {
 		return [];
 	}
-
-	const includeDrafts = _options?.includeDrafts ?? false;
 
 	return fs
 		.readdirSync(blogDir, { withFileTypes: true })
@@ -63,14 +59,25 @@ export function listBlogSlugs(_options?: {
 		.map((entry) => entry.name)
 		.filter((name) => name.endsWith(".mdx"))
 		.filter((name) => !name.startsWith("_"))
-		.filter((name) => {
-			if (includeDrafts) {
-				return true;
-			}
-			const status = getFrontmatterStatusFromFile(path.join(blogDir, name));
-			return status !== "draft";
-		})
 		.map((name) => name.replace(/\.mdx$/, ""));
+}
+
+export function listBlogSlugs(_options?: {
+	includeDrafts?: boolean;
+}): string[] {
+	const includeDrafts = _options?.includeDrafts ?? false;
+	const slugs = getCandidateSlugs();
+
+	if (includeDrafts) {
+		return slugs;
+	}
+
+	return slugs.filter((slug) => {
+		const status = getFrontmatterStatusFromFile(
+			path.join(blogDir, `${slug}.mdx`),
+		);
+		return status !== "draft";
+	});
 }
 
 export async function loadBlogPost(slug: string): Promise<BlogPost> {
@@ -101,7 +108,7 @@ export async function listBlogPosts(options?: {
 	includeDrafts?: boolean;
 }): Promise<BlogPostSummary[]> {
 	const includeDrafts = options?.includeDrafts ?? false;
-	const slugs = listBlogSlugs({ includeDrafts });
+	const slugs = getCandidateSlugs();
 
 	const posts = await Promise.all(
 		slugs.map(async (slug) => {
@@ -110,7 +117,11 @@ export async function listBlogPosts(options?: {
 		}),
 	);
 
-	return posts.sort(
+	const filteredPosts = includeDrafts
+		? posts
+		: posts.filter((post) => post.frontmatter.status !== "draft");
+
+	return filteredPosts.sort(
 		(a, b) => Date.parse(b.frontmatter.date) - Date.parse(a.frontmatter.date),
 	);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the performance issue where `listBlogPosts()` was reading MDX files twice:
1. First via `listBlogSlugs()` calling `getFrontmatterStatusFromFile()` with `fs.readFileSync` + `gray-matter`
2. Then via `loadBlogPost()` doing a dynamic `import()`

## Changes

- Extract `getCandidateSlugs()` helper to list MDX file slugs from filenames only (no file I/O beyond directory listing)
- `listBlogPosts()` now uses `getCandidateSlugs()` directly and filters drafts after MDX import
- `listBlogSlugs()` continues to read frontmatter for standalone callers (sitemap, generateStaticParams) that only need slugs

## Acceptance Criteria

- [x] Build-time file I/O is reduced (no double read in `listBlogPosts`)
- [x] Existing draft filter behavior is unchanged
- [x] All tests pass
- [x] Build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77a2efc1-66c1-4de5-bc98-38d84651b34c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77a2efc1-66c1-4de5-bc98-38d84651b34c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

