### PR TITLE
feat: add RSS 2.0 feed for published blog posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ content/blog/*.mdx → lib/content/blog/mdx.ts → app/blog/[slug]/page.tsx → 
 | `lib/metadata/blog-posting.ts` | BlogPosting JSON-LD builder |
 | `lib/metadata/json-ld.ts` | Safe JSON-LD serialization |
 | `lib/metadata/sitemap.ts` | Sitemap entry builder |
+| `lib/metadata/feed.ts` | RSS 2.0 feed builder |
 | `lib/link-card/extract-hrefs.ts` | Extract `<LinkCard href="...">` URLs from MDX source |
 | `lib/link-preview/types.ts` | Link preview cache types |
 | `lib/link-preview/cache.ts` | LinkCard OGP preview cache loader |
@@ -62,6 +63,7 @@ content/blog/*.mdx → lib/content/blog/mdx.ts → app/blog/[slug]/page.tsx → 
 | `scripts/fetch-link-previews.ts` | Build-time OGP fetch for `<LinkCard>` URLs |
 | `content/generated/link-previews.json` | Cached external link previews |
 | `app/sitemap.ts` | Build-time sitemap generation |
+| `app/feed.xml/route.ts` | Build-time RSS feed generation |
 | `.github/workflows/ci.yml` | CI (Biome check + test + build + zizmor) |
 
 ## Dev environment

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,7 +3,11 @@ import { notFound } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { listBlogSlugs, loadBlogPost } from "@/lib/content/blog/mdx";
 import { blogPostingJsonLd, jsonLdScript } from "@/lib/metadata/json-ld";
-import { pageOpenGraph, pageTwitter } from "@/lib/metadata/page";
+import {
+	pageAlternates,
+	pageOpenGraph,
+	pageTwitter,
+} from "@/lib/metadata/page";
 import { config } from "@/lib/site/config";
 import { blogPostOgImagePath } from "@/lib/site/routes";
 import { DemotedMdxH1 } from "@/mdx-components";
@@ -34,7 +38,7 @@ export async function generateMetadata({
 	return {
 		title,
 		description,
-		alternates: { canonical: path },
+		alternates: pageAlternates(path),
 		openGraph: pageOpenGraph({
 			title,
 			description,

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { listBlogPosts } from "@/lib/content/blog/mdx";
-import { pageOpenGraph, pageTwitter } from "@/lib/metadata/page";
+import {
+	pageAlternates,
+	pageOpenGraph,
+	pageTwitter,
+} from "@/lib/metadata/page";
 import { config } from "@/lib/site/config";
 import { ogImagePaths } from "@/lib/site/routes";
 
@@ -13,7 +17,7 @@ const imagePath = ogImagePaths.blog;
 export const metadata: Metadata = {
 	title,
 	description,
-	alternates: { canonical: "/blog" },
+	alternates: pageAlternates("/blog"),
 	openGraph: pageOpenGraph({
 		title,
 		description,

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,32 @@
+import { loadBlogFrontmatter } from "@/lib/content/blog/files";
+import { listBlogSlugs } from "@/lib/content/blog/mdx";
+import { buildRssFeed } from "@/lib/metadata/feed";
+import { config } from "@/lib/site/config";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	const origin = config.site.prodOrigin;
+	const posts = listBlogSlugs().map((slug) => {
+		const frontmatter = loadBlogFrontmatter(slug);
+		if (!frontmatter) {
+			throw new Error(`Missing frontmatter for ${slug}`);
+		}
+
+		return { slug, frontmatter };
+	});
+
+	const feed = buildRssFeed({
+		origin,
+		siteName: config.site.name,
+		siteDescription: config.site.description,
+		authorName: config.site.authorName,
+		posts,
+	});
+
+	return new Response(feed, {
+		headers: {
+			"Content-Type": "application/rss+xml; charset=utf-8",
+		},
+	});
+}

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -20,7 +20,6 @@ export function GET() {
 		origin,
 		siteName: config.site.name,
 		siteDescription: config.site.description,
-		authorName: config.site.authorName,
 		posts,
 	});
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,11 @@ export const metadata: Metadata = {
 	},
 	description: config.site.description,
 	robots: { index: true, follow: true },
+	alternates: {
+		types: {
+			"application/rss+xml": "/feed.xml",
+		},
+	},
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,11 +18,6 @@ export const metadata: Metadata = {
 	},
 	description: config.site.description,
 	robots: { index: true, follow: true },
-	alternates: {
-		types: {
-			"application/rss+xml": "/feed.xml",
-		},
-	},
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { TypographyH1, TypographyP } from "@/components/typography";
 import { jsonLdScript, webSiteJsonLd } from "@/lib/metadata/json-ld";
-import { pageOpenGraph, pageTwitter } from "@/lib/metadata/page";
+import {
+	pageAlternates,
+	pageOpenGraph,
+	pageTwitter,
+} from "@/lib/metadata/page";
 import { config } from "@/lib/site/config";
 import { ogImagePaths } from "@/lib/site/routes";
 
@@ -13,7 +17,7 @@ const imagePath = ogImagePaths.home;
 export const metadata: Metadata = {
 	title,
 	description,
-	alternates: { canonical: "/" },
+	alternates: pageAlternates("/"),
 	openGraph: pageOpenGraph({
 		title,
 		description,

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import PrivacyContent, { frontmatter } from "@/content/pages/privacy.mdx";
+import { pageAlternates } from "@/lib/metadata/page";
 
 export const metadata: Metadata = {
 	title: frontmatter.title,
 	description: frontmatter.description,
-	alternates: { canonical: "/privacy" },
+	alternates: pageAlternates("/privacy"),
 	robots: { index: true, follow: true },
 };
 

--- a/lib/metadata/feed.test.ts
+++ b/lib/metadata/feed.test.ts
@@ -7,7 +7,6 @@ const feedOptions = {
 	origin,
 	siteName: "nozo.dev",
 	siteDescription: "技術メモと備忘録をまとめるブログ。",
-	authorName: "Nozomi Hijikata",
 };
 
 describe("escapeXml", () => {

--- a/lib/metadata/feed.test.ts
+++ b/lib/metadata/feed.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { buildRssFeed, escapeXml, formatRssPubDate } from "@/lib/metadata/feed";
+
+const origin = "https://nozo.dev";
+
+const feedOptions = {
+	origin,
+	siteName: "nozo.dev",
+	siteDescription: "技術メモと備忘録をまとめるブログ。",
+	authorName: "Nozomi Hijikata",
+};
+
+describe("escapeXml", () => {
+	test("escapes XML special characters", () => {
+		expect(escapeXml(`Tom & Jerry's "RSS" <feed>`)).toBe(
+			"Tom &amp; Jerry&apos;s &quot;RSS&quot; &lt;feed&gt;",
+		);
+	});
+});
+
+describe("formatRssPubDate", () => {
+	test("formats ISO dates as RFC 822 UTC strings", () => {
+		expect(formatRssPubDate("2026-02-04")).toBe(
+			"Wed, 04 Feb 2026 00:00:00 GMT",
+		);
+	});
+});
+
+describe("buildRssFeed", () => {
+	test("includes channel metadata and feed self link", () => {
+		const feed = buildRssFeed({ ...feedOptions, posts: [] });
+
+		expect(feed).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+		expect(feed).toContain("<title>nozo.dev</title>");
+		expect(feed).toContain("<link>https://nozo.dev/blog</link>");
+		expect(feed).toContain(
+			'<atom:link href="https://nozo.dev/feed.xml" rel="self" type="application/rss+xml"/>',
+		);
+		expect(feed).toContain("<language>ja</language>");
+	});
+
+	test("sorts items with the freshest post first", () => {
+		const feed = buildRssFeed({
+			...feedOptions,
+			posts: [
+				{
+					slug: "older",
+					frontmatter: {
+						title: "Older",
+						description: "Older post",
+						date: "2026-01-01",
+						status: "published",
+					},
+				},
+				{
+					slug: "newer",
+					frontmatter: {
+						title: "Newer",
+						description: "Newer post",
+						date: "2026-02-11",
+						status: "published",
+					},
+				},
+			],
+		});
+
+		expect(feed.indexOf("/blog/newer")).toBeLessThan(
+			feed.indexOf("/blog/older"),
+		);
+	});
+
+	test("uses updatedAt for pubDate when set", () => {
+		const feed = buildRssFeed({
+			...feedOptions,
+			posts: [
+				{
+					slug: "updated-post",
+					frontmatter: {
+						title: "Updated",
+						description: "Updated post",
+						date: "2026-01-01",
+						updatedAt: "2026-06-25",
+						status: "published",
+					},
+				},
+			],
+		});
+
+		expect(feed).toContain("<pubDate>Thu, 25 Jun 2026 00:00:00 GMT</pubDate>");
+	});
+
+	test("escapes special characters in item fields", () => {
+		const feed = buildRssFeed({
+			...feedOptions,
+			posts: [
+				{
+					slug: "xml-test",
+					frontmatter: {
+						title: `Tom & Jerry's "RSS"`,
+						description: "Description with <tags> & more",
+						date: "2026-02-04",
+						status: "published",
+					},
+				},
+			],
+		});
+
+		expect(feed).toContain(
+			"<title>Tom &amp; Jerry&apos;s &quot;RSS&quot;</title>",
+		);
+		expect(feed).toContain(
+			"<description>Description with &lt;tags&gt; &amp; more</description>",
+		);
+	});
+});

--- a/lib/metadata/feed.ts
+++ b/lib/metadata/feed.ts
@@ -12,7 +12,6 @@ export type RssFeedOptions = {
 	origin: string;
 	siteName: string;
 	siteDescription: string;
-	authorName: string;
 	posts: FeedBlogPost[];
 };
 
@@ -53,7 +52,7 @@ function buildRssItem(origin: string, post: FeedBlogPost): string {
 }
 
 export function buildRssFeed(options: RssFeedOptions): string {
-	const { origin, siteName, siteDescription, authorName, posts } = options;
+	const { origin, siteName, siteDescription, posts } = options;
 	const feedUrl = `${origin}/feed.xml`;
 	const blogUrl = `${origin}/blog`;
 	const sortedPosts = sortPostsByFreshness(posts);
@@ -72,7 +71,6 @@ export function buildRssFeed(options: RssFeedOptions): string {
 <link>${escapeXml(blogUrl)}</link>
 <description>${escapeXml(siteDescription)}</description>
 <language>ja</language>
-<managingEditor>${escapeXml(authorName)}</managingEditor>
 <lastBuildDate>${latestPubDate}</lastBuildDate>
 <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>
 ${items}

--- a/lib/metadata/feed.ts
+++ b/lib/metadata/feed.ts
@@ -1,0 +1,81 @@
+import {
+	type BlogFrontmatter,
+	blogPostFreshnessDate,
+} from "@/lib/content/blog/schema";
+
+export type FeedBlogPost = {
+	slug: string;
+	frontmatter: BlogFrontmatter;
+};
+
+export type RssFeedOptions = {
+	origin: string;
+	siteName: string;
+	siteDescription: string;
+	authorName: string;
+	posts: FeedBlogPost[];
+};
+
+export function escapeXml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&apos;");
+}
+
+export function formatRssPubDate(isoDate: string): string {
+	const date = new Date(`${isoDate}T00:00:00.000Z`);
+	return date.toUTCString();
+}
+
+function sortPostsByFreshness(posts: FeedBlogPost[]): FeedBlogPost[] {
+	return [...posts].sort(
+		(a, b) =>
+			Date.parse(blogPostFreshnessDate(b.frontmatter)) -
+			Date.parse(blogPostFreshnessDate(a.frontmatter)),
+	);
+}
+
+function buildRssItem(origin: string, post: FeedBlogPost): string {
+	const { title, description } = post.frontmatter;
+	const link = `${origin}/blog/${post.slug}`;
+	const pubDate = formatRssPubDate(blogPostFreshnessDate(post.frontmatter));
+
+	return `<item>
+<title>${escapeXml(title)}</title>
+<link>${escapeXml(link)}</link>
+<guid isPermaLink="true">${escapeXml(link)}</guid>
+<pubDate>${pubDate}</pubDate>
+<description>${escapeXml(description)}</description>
+</item>`;
+}
+
+export function buildRssFeed(options: RssFeedOptions): string {
+	const { origin, siteName, siteDescription, authorName, posts } = options;
+	const feedUrl = `${origin}/feed.xml`;
+	const blogUrl = `${origin}/blog`;
+	const sortedPosts = sortPostsByFreshness(posts);
+	const items = sortedPosts
+		.map((post) => buildRssItem(origin, post))
+		.join("\n");
+
+	const latestPubDate = sortedPosts[0]
+		? formatRssPubDate(blogPostFreshnessDate(sortedPosts[0].frontmatter))
+		: formatRssPubDate(new Date().toISOString().slice(0, 10));
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+<title>${escapeXml(siteName)}</title>
+<link>${escapeXml(blogUrl)}</link>
+<description>${escapeXml(siteDescription)}</description>
+<language>ja</language>
+<managingEditor>${escapeXml(authorName)}</managingEditor>
+<lastBuildDate>${latestPubDate}</lastBuildDate>
+<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>
+${items}
+</channel>
+</rss>`;
+}

--- a/lib/metadata/page.test.ts
+++ b/lib/metadata/page.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { pageOpenGraph, pageTwitter } from "@/lib/metadata/page";
+import {
+	pageAlternates,
+	pageOpenGraph,
+	pageTwitter,
+} from "@/lib/metadata/page";
 import { config } from "@/lib/site/config";
 import { ogImagePaths } from "@/lib/site/routes";
+
+describe("pageAlternates", () => {
+	test("includes canonical URL and RSS feed type", () => {
+		expect(pageAlternates("/blog")).toEqual({
+			canonical: "/blog",
+			types: {
+				"application/rss+xml": "/feed.xml",
+			},
+		});
+	});
+});
 
 describe("pageOpenGraph", () => {
 	test("builds website metadata with defaults", () => {

--- a/lib/metadata/page.ts
+++ b/lib/metadata/page.ts
@@ -1,6 +1,19 @@
 import type { Metadata } from "next";
 import { config } from "@/lib/site/config";
 
+export const rssFeedPath = "/feed.xml";
+
+export function pageAlternates(
+	canonical: string,
+): NonNullable<Metadata["alternates"]> {
+	return {
+		canonical,
+		types: {
+			"application/rss+xml": rssFeedPath,
+		},
+	};
+}
+
 type OpenGraphPageOptions = {
 	title: string;
 	description: string;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://nozo.dev/sitemap.xml
+Feed: https://nozo.dev/feed.xml


### PR DESCRIPTION
## Summary

- Add `/feed.xml` as a build-time RSS 2.0 feed generated from published blog frontmatter (same pipeline as the sitemap)
- Extract XML generation into `lib/metadata/feed.ts` with unit tests for sorting, pubDate, and escaping
- Expose the feed via `<link rel="alternate">` in the root layout and a `Feed:` entry in `robots.txt`

Closes #30

## Test plan

- [x] `bun run check`
- [x] `bun test`
- [x] `bun run build` produces `out/feed.xml`
- [x] Feed items are sorted newest-first and exclude drafts
- [ ] Verify `/feed.xml` in dev and confirm RSS reader subscription after deploy


Made with [Cursor](https://cursor.com)